### PR TITLE
git-blame.el include author info

### DIFF
--- a/git-blame.el
+++ b/git-blame.el
@@ -371,7 +371,7 @@ See also function `git-blame-mode'."
 (defun git-describe-commit (hash)
   (with-temp-buffer
     (call-process "git" nil t nil
-                  "log" "-1" "--pretty=oneline"
+                  "log" "-1" "--pretty=format:\"%H %an -- %s\""
                   hash)
     (buffer-substring (point-min) (1- (point-max)))))
 


### PR DESCRIPTION
One of the main reasons I use git blame is to figure out who i can go to for an explanation, question, permission, etc to change code.  I think it would be nice to include the author's name in the blame info.  I kept the rest of the information intact.  Following is a before and after:

Before:
799d9a884e7af5781a2eec79ee98bd432e7297b8 improve git blame info to include author

After:
799d9a884e7af5781a2eec79ee98bd432e7297b8 Justin Caratzas -- improve git blame info to include author

Cheers!
Justin Caratzas
