### PR TITLE
Fixing issue with git grep when color=auto on .gitconfig

### DIFF
--- a/git-emacs.el
+++ b/git-emacs.el
@@ -2518,7 +2518,7 @@ that variable in .emacs.
         (grep-use-null-device nil))
     (add-hook 'grep-setup-hook git-grep-setup-hook)
     (unwind-protect
-         (grep (concat "git grep -n " args))
+         (grep (concat "git grep --no-color -n " args))
       (remove-hook 'grep-setup-hook git-grep-setup-hook))))
 
 


### PR DESCRIPTION
This is so if you have color auto in your git config it doesn't break
the file links inside emacs
