### PR TITLE
rename git-blame.el to git-blamed.el, to avoid conflict

### DIFF
--- a/git-blamed.el
+++ b/git-blamed.el
@@ -1,4 +1,4 @@
-;;; git-blame.el --- Minor mode for incremental blame for Git  -*- coding: utf-8 -*-
+;;; git-blamed.el --- Minor mode for incremental blame for Git  -*- coding: utf-8 -*-
 ;;
 ;; Copyright (C) 2007  David Kågedal
 ;;
@@ -45,19 +45,19 @@
 ;;; Installation:
 ;;
 ;; To use this package, put it somewhere in `load-path' (or add
-;; directory with git-blame.el to `load-path'), and add the following
+;; directory with git-blamed.el to `load-path'), and add the following
 ;; line to your .emacs:
 ;;
-;;    (require 'git-blame)
+;;    (require 'git-blamed)
 ;;
 ;; If you do not want to load this package before it is necessary, you
 ;; can make use of the `autoload' feature, e.g. by adding to your .emacs
 ;; the following lines
 ;;
-;;    (autoload 'git-blame-mode "git-blame"
+;;    (autoload 'git-blamed-mode "git-blamed"
 ;;              "Minor mode for incremental blame for Git." t)
 ;;
-;; Then first use of `M-x git-blame-mode' would load the package.
+;; Then first use of `M-x git-blamed-mode' would load the package.
 
 ;;; Compatibility:
 ;;
@@ -81,7 +81,7 @@
 (eval-when-compile (require 'cl))			      ; to use `push', `pop'
 
 
-(defun git-blame-color-scale (&rest elements)
+(defun git-blamed-color-scale (&rest elements)
   "Given a list, returns a list of triples formed with each
 elements of the list.
 
@@ -93,11 +93,11 @@ a b => bbb bba bab baa abb aba aaa aab"
           (setq result (cons (format "#%s%s%s" a b c) result)))))
     result))
 
-;; (git-blame-color-scale "0c" "04" "24" "1c" "2c" "34" "14" "3c") =>
+;; (git-blamed-color-scale "0c" "04" "24" "1c" "2c" "34" "14" "3c") =>
 ;; ("#3c3c3c" "#3c3c14" "#3c3c34" "#3c3c2c" "#3c3c1c" "#3c3c24"
 ;; "#3c3c04" "#3c3c0c" "#3c143c" "#3c1414" "#3c1434" "#3c142c" ...)
 
-(defmacro git-blame-random-pop (l)
+(defmacro git-blamed-random-pop (l)
   "Select a random element from L and returns it. Also remove
 selected element from l."
   ;; only works on lists with unique elements
@@ -105,111 +105,111 @@ selected element from l."
      (setq ,l (remove e ,l))
      e))
 
-(defvar git-blame-dark-colors
-  (git-blame-color-scale "0c" "04" "24" "1c" "2c" "34" "14" "3c")
+(defvar git-blamed-dark-colors
+  (git-blamed-color-scale "0c" "04" "24" "1c" "2c" "34" "14" "3c")
   "*List of colors (format #RGB) to use in a dark environment.
 
-To check out the list, evaluate (list-colors-display git-blame-dark-colors).")
+To check out the list, evaluate (list-colors-display git-blamed-dark-colors).")
 
-(defvar git-blame-light-colors
-  (git-blame-color-scale "c4" "d4" "cc" "dc" "f4" "e4" "fc" "ec")
+(defvar git-blamed-light-colors
+  (git-blamed-color-scale "c4" "d4" "cc" "dc" "f4" "e4" "fc" "ec")
   "*List of colors (format #RGB) to use in a light environment.
 
-To check out the list, evaluate (list-colors-display git-blame-light-colors).")
+To check out the list, evaluate (list-colors-display git-blamed-light-colors).")
 
-(defvar git-blame-colors '()
-  "Colors used by git-blame. The list is built once when activating git-blame
+(defvar git-blamed-colors '()
+  "Colors used by git-blamed. The list is built once when activating git-blamed
 minor mode.")
 
-(defvar git-blame-ancient-color "dark green"
+(defvar git-blamed-ancient-color "dark green"
   "*Color to be used for ancient commit.")
 
-(defvar git-blame-autoupdate t
+(defvar git-blamed-autoupdate t
   "*Automatically update the blame display while editing")
 
-(defvar git-blame-proc nil
-  "The running git-blame process")
-(make-variable-buffer-local 'git-blame-proc)
+(defvar git-blamed-proc nil
+  "The running git-blamed process")
+(make-variable-buffer-local 'git-blamed-proc)
 
-(defvar git-blame-overlays nil
-  "The git-blame overlays used in the current buffer.")
-(make-variable-buffer-local 'git-blame-overlays)
+(defvar git-blamed-overlays nil
+  "The git-blamed overlays used in the current buffer.")
+(make-variable-buffer-local 'git-blamed-overlays)
 
-(defvar git-blame-cache nil
-  "A cache of git-blame information for the current buffer")
-(make-variable-buffer-local 'git-blame-cache)
+(defvar git-blamed-cache nil
+  "A cache of git-blamed information for the current buffer")
+(make-variable-buffer-local 'git-blamed-cache)
 
-(defvar git-blame-idle-timer nil
+(defvar git-blamed-idle-timer nil
   "An idle timer that updates the blame")
-(make-variable-buffer-local 'git-blame-cache)
+(make-variable-buffer-local 'git-blamed-cache)
 
-(defvar git-blame-update-queue nil
+(defvar git-blamed-update-queue nil
   "A queue of update requests")
-(make-variable-buffer-local 'git-blame-update-queue)
+(make-variable-buffer-local 'git-blamed-update-queue)
 
 ;; FIXME: docstrings
-(defvar git-blame-file nil)
-(defvar git-blame-current nil)
+(defvar git-blamed-file nil)
+(defvar git-blamed-current nil)
 
-(defvar git-blame-mode nil)
-(make-variable-buffer-local 'git-blame-mode)
+(defvar git-blamed-mode nil)
+(make-variable-buffer-local 'git-blamed-mode)
 
-(defvar git-blame-mode-line-string " blame"
-  "String to display on the mode line when git-blame is active.")
+(defvar git-blamed-mode-line-string " blame"
+  "String to display on the mode line when git-blamed is active.")
 
-(or (assq 'git-blame-mode minor-mode-alist)
+(or (assq 'git-blamed-mode minor-mode-alist)
     (setq minor-mode-alist
-	  (cons '(git-blame-mode git-blame-mode-line-string) minor-mode-alist)))
+	  (cons '(git-blamed-mode git-blamed-mode-line-string) minor-mode-alist)))
 
 ;;;###autoload
-(defun git-blame-mode (&optional arg)
+(defun git-blamed-mode (&optional arg)
   "Toggle minor mode for displaying Git blame
 
 With prefix ARG, turn the mode on if ARG is positive."
   (interactive "P")
   (cond
    ((null arg)
-    (if git-blame-mode (git-blame-mode-off) (git-blame-mode-on)))
-   ((> (prefix-numeric-value arg) 0) (git-blame-mode-on))
-   (t (git-blame-mode-off))))
+    (if git-blamed-mode (git-blamed-mode-off) (git-blamed-mode-on)))
+   ((> (prefix-numeric-value arg) 0) (git-blamed-mode-on))
+   (t (git-blamed-mode-off))))
 
-(defun git-blame-mode-on ()
-  "Turn on git-blame mode.
+(defun git-blamed-mode-on ()
+  "Turn on git-blamed mode.
 
-See also function `git-blame-mode'."
-  (make-local-variable 'git-blame-colors)
-  (if git-blame-autoupdate
-      (add-hook 'after-change-functions 'git-blame-after-change nil t)
-    (remove-hook 'after-change-functions 'git-blame-after-change t))
-  (git-blame-cleanup)
+See also function `git-blamed-mode'."
+  (make-local-variable 'git-blamed-colors)
+  (if git-blamed-autoupdate
+      (add-hook 'after-change-functions 'git-blamed-after-change nil t)
+    (remove-hook 'after-change-functions 'git-blamed-after-change t))
+  (git-blamed-cleanup)
   (let ((bgmode (cdr (assoc 'background-mode (frame-parameters)))))
     (if (eq bgmode 'dark)
-	(setq git-blame-colors git-blame-dark-colors)
-      (setq git-blame-colors git-blame-light-colors)))
-  (setq git-blame-cache (make-hash-table :test 'equal))
-  (setq git-blame-mode t)
-  (git-blame-run))
+	(setq git-blamed-colors git-blamed-dark-colors)
+      (setq git-blamed-colors git-blamed-light-colors)))
+  (setq git-blamed-cache (make-hash-table :test 'equal))
+  (setq git-blamed-mode t)
+  (git-blamed-run))
 
-(defun git-blame-mode-off ()
-  "Turn off git-blame mode.
+(defun git-blamed-mode-off ()
+  "Turn off git-blamed mode.
 
-See also function `git-blame-mode'."
-  (git-blame-cleanup)
-  (if git-blame-idle-timer (cancel-timer git-blame-idle-timer))
-  (setq git-blame-mode nil))
+See also function `git-blamed-mode'."
+  (git-blamed-cleanup)
+  (if git-blamed-idle-timer (cancel-timer git-blamed-idle-timer))
+  (setq git-blamed-mode nil))
 
 ;;;###autoload
 (defun git-reblame ()
   "Recalculate all blame information in the current buffer"
   (interactive)
-  (unless git-blame-mode
-    (error "Git-blame is not active"))
+  (unless git-blamed-mode
+    (error "git-blamed is not active"))
 
-  (git-blame-cleanup)
-  (git-blame-run))
+  (git-blamed-cleanup)
+  (git-blamed-run))
 
-(defun git-blame-run (&optional startline endline)
-  (if git-blame-proc
+(defun git-blamed-run (&optional startline endline)
+  (if git-blamed-proc
       ;; Should maybe queue up a new run here
       (message "Already running git blame")
     (let ((display-buf (current-buffer))
@@ -221,35 +221,35 @@ See also function `git-blame-mode'."
                              (list "-L" (format "%d,%d" startline endline)))))
       (setq args (append args
                          (list (file-name-nondirectory buffer-file-name))))
-      (setq git-blame-proc
+      (setq git-blamed-proc
             (apply 'start-process
-                   "git-blame" blame-buf
+                   "git-blamed" blame-buf
                    "git" "blame"
                    args))
       (with-current-buffer blame-buf
         (erase-buffer)
-        (make-local-variable 'git-blame-file)
-        (make-local-variable 'git-blame-current)
-        (setq git-blame-file display-buf)
-        (setq git-blame-current nil))
-      (set-process-filter git-blame-proc 'git-blame-filter)
-      (set-process-sentinel git-blame-proc 'git-blame-sentinel)
-      (process-send-region git-blame-proc (point-min) (point-max))
-      (process-send-eof git-blame-proc))))
+        (make-local-variable 'git-blamed-file)
+        (make-local-variable 'git-blamed-current)
+        (setq git-blamed-file display-buf)
+        (setq git-blamed-current nil))
+      (set-process-filter git-blamed-proc 'git-blamed-filter)
+      (set-process-sentinel git-blamed-proc 'git-blamed-sentinel)
+      (process-send-region git-blamed-proc (point-min) (point-max))
+      (process-send-eof git-blamed-proc))))
 
-(defun remove-git-blame-text-properties (start end)
+(defun remove-git-blamed-text-properties (start end)
   (let ((modified (buffer-modified-p))
         (inhibit-read-only t))
     (remove-text-properties start end '(point-entered nil))
     (set-buffer-modified-p modified)))
 
-(defun git-blame-cleanup ()
+(defun git-blamed-cleanup ()
   "Remove all blame properties"
-    (mapc 'delete-overlay git-blame-overlays)
-    (setq git-blame-overlays nil)
-    (remove-git-blame-text-properties (point-min) (point-max)))
+  (mapc 'delete-overlay git-blamed-overlays)
+  (setq git-blamed-overlays nil)
+  (remove-git-blamed-text-properties (point-min) (point-max)))
 
-(defun git-blame-update-region (start end)
+(defun git-blamed-update-region (start end)
   "Rerun blame to get updates between START and END"
   (let ((overlays (overlays-in start end)))
     (while overlays
@@ -258,26 +258,26 @@ See also function `git-blame-mode'."
             (setq start (overlay-start overlay)))
         (if (> (overlay-end overlay) end)
             (setq end (overlay-end overlay)))
-        (setq git-blame-overlays (delete overlay git-blame-overlays))
+        (setq git-blamed-overlays (delete overlay git-blamed-overlays))
         (delete-overlay overlay))))
-  (remove-git-blame-text-properties start end)
+  (remove-git-blamed-text-properties start end)
   ;; We can be sure that start and end are at line breaks
-  (git-blame-run (1+ (count-lines (point-min) start))
-                 (count-lines (point-min) end)))
+  (git-blamed-run (1+ (count-lines (point-min) start))
+                  (count-lines (point-min) end)))
 
-(defun git-blame-sentinel (proc status)
+(defun git-blamed-sentinel (proc status)
   (with-current-buffer (process-buffer proc)
-    (with-current-buffer git-blame-file
-      (setq git-blame-proc nil)
-      (if git-blame-update-queue
-          (git-blame-delayed-update))))
+    (with-current-buffer git-blamed-file
+      (setq git-blamed-proc nil)
+      (if git-blamed-update-queue
+          (git-blamed-delayed-update))))
   ;;(kill-buffer (process-buffer proc))
   ;;(message "git blame finished")
   )
 
 (defvar in-blame-filter nil)
 
-(defun git-blame-filter (proc str)
+(defun git-blamed-filter (proc str)
   (save-excursion
     (set-buffer (process-buffer proc))
     (goto-char (process-mark proc))
@@ -287,83 +287,83 @@ See also function `git-blame-mode'."
       (let ((more t)
             (in-blame-filter t))
         (while more
-          (setq more (git-blame-parse)))))))
+          (setq more (git-blamed-parse)))))))
 
-(defun git-blame-parse ()
+(defun git-blamed-parse ()
   (cond ((looking-at "\\([0-9a-f]\\{40\\}\\) \\([0-9]+\\) \\([0-9]+\\) \\([0-9]+\\)\n")
          (let ((hash (match-string 1))
                (src-line (string-to-number (match-string 2)))
                (res-line (string-to-number (match-string 3)))
                (num-lines (string-to-number (match-string 4))))
-           (setq git-blame-current
+           (setq git-blamed-current
                  (if (string= hash "0000000000000000000000000000000000000000")
                      nil
-                   (git-blame-new-commit
+                   (git-blamed-new-commit
                     hash src-line res-line num-lines))))
          (delete-region (point) (match-end 0))
          t)
         ((looking-at "filename \\(.+\\)\n")
          (let ((filename (match-string 1)))
-           (git-blame-add-info "filename" filename))
+           (git-blamed-add-info "filename" filename))
          (delete-region (point) (match-end 0))
          t)
         ((looking-at "\\([a-z-]+\\) \\(.+\\)\n")
          (let ((key (match-string 1))
                (value (match-string 2)))
-           (git-blame-add-info key value))
+           (git-blamed-add-info key value))
          (delete-region (point) (match-end 0))
          t)
         ((looking-at "boundary\n")
-         (setq git-blame-current nil)
+         (setq git-blamed-current nil)
          (delete-region (point) (match-end 0))
          t)
         (t
          nil)))
 
-(defun git-blame-new-commit (hash src-line res-line num-lines)
+(defun git-blamed-new-commit (hash src-line res-line num-lines)
   (save-excursion
-    (set-buffer git-blame-file)
-    (let ((info (gethash hash git-blame-cache))
+    (set-buffer git-blamed-file)
+    (let ((info (gethash hash git-blamed-cache))
           (inhibit-point-motion-hooks t)
           (inhibit-modification-hooks t))
       (when (not info)
 	;; Assign a random color to each new commit info
 	;; Take care not to select the same color multiple times
-	(let ((color (if git-blame-colors
-			 (git-blame-random-pop git-blame-colors)
-		       git-blame-ancient-color)))
+	(let ((color (if git-blamed-colors
+			 (git-blamed-random-pop git-blamed-colors)
+		       git-blamed-ancient-color)))
           (setq info (list hash src-line res-line num-lines
                            (git-describe-commit hash)
                            (cons 'color color))))
-        (puthash hash info git-blame-cache))
+        (puthash hash info git-blamed-cache))
       (goto-line res-line)
       (while (> num-lines 0)
-        (if (get-text-property (point) 'git-blame)
+        (if (get-text-property (point) 'git-blamed)
             (forward-line)
           (let* ((start (point))
                  (end (progn (forward-line 1) (point)))
                  (ovl (make-overlay start end)))
-            (push ovl git-blame-overlays)
-            (overlay-put ovl 'git-blame info)
+            (push ovl git-blamed-overlays)
+            (overlay-put ovl 'git-blamed info)
             (overlay-put ovl 'help-echo hash)
             (overlay-put ovl 'face (list :background
                                          (cdr (assq 'color (nthcdr 5 info)))))
             ;; the point-entered property doesn't seem to work in overlays
             ;;(overlay-put ovl 'point-entered
-            ;;             `(lambda (x y) (git-blame-identify ,hash)))
+            ;;             `(lambda (x y) (git-blamed-identify ,hash)))
             (let ((modified (buffer-modified-p)))
               (put-text-property (if (= start 1) start (1- start)) (1- end)
                                  'point-entered
-                                 `(lambda (x y) (git-blame-identify ,hash)))
+                                 `(lambda (x y) (git-blamed-identify ,hash)))
               (set-buffer-modified-p modified))))
         (setq num-lines (1- num-lines))))))
 
-(defun git-blame-add-info (key value)
-  (if git-blame-current
-      (nconc git-blame-current (list (cons (intern key) value)))))
+(defun git-blamed-add-info (key value)
+  (if git-blamed-current
+      (nconc git-blamed-current (list (cons (intern key) value)))))
 
-(defun git-blame-current-commit ()
-  (let ((info (get-char-property (point) 'git-blame)))
+(defun git-blamed-current-commit ()
+  (let ((info (get-char-property (point) 'git-blamed)))
     (if info
         (car info)
       (error "No commit info"))))
@@ -375,52 +375,52 @@ See also function `git-blame-mode'."
                   hash)
     (buffer-substring (point-min) (1- (point-max)))))
 
-(defvar git-blame-last-identification nil)
-(make-variable-buffer-local 'git-blame-last-identification)
-(defun git-blame-identify (&optional hash)
+(defvar git-blamed-last-identification nil)
+(make-variable-buffer-local 'git-blamed-last-identification)
+(defun git-blamed-identify (&optional hash)
   (interactive)
-  (let ((info (gethash (or hash (git-blame-current-commit)) git-blame-cache)))
-    (when (and info (not (eq info git-blame-last-identification)))
+  (let ((info (gethash (or hash (git-blamed-current-commit)) git-blamed-cache)))
+    (when (and info (not (eq info git-blamed-last-identification)))
       (message "%s" (nth 4 info))
-      (setq git-blame-last-identification info))))
+      (setq git-blamed-last-identification info))))
 
-;; (defun git-blame-after-save ()
-;;   (when git-blame-mode
-;;     (git-blame-cleanup)
-;;     (git-blame-run)))
-;; (add-hook 'after-save-hook 'git-blame-after-save)
+;; (defun git-blamed-after-save ()
+;;   (when git-blamed-mode
+;;     (git-blamed-cleanup)
+;;     (git-blamed-run)))
+;; (add-hook 'after-save-hook 'git-blamed-after-save)
 
-(defun git-blame-after-change (start end length)
-  (when git-blame-mode
-    (git-blame-enq-update start end)))
+(defun git-blamed-after-change (start end length)
+  (when git-blamed-mode
+    (git-blamed-enq-update start end)))
 
-(defvar git-blame-last-update nil)
-(make-variable-buffer-local 'git-blame-last-update)
-(defun git-blame-enq-update (start end)
+(defvar git-blamed-last-update nil)
+(make-variable-buffer-local 'git-blamed-last-update)
+(defun git-blamed-enq-update (start end)
   "Mark the region between START and END as needing blame update"
   ;; Try to be smart and avoid multiple callouts for sequential
   ;; editing
-  (cond ((and git-blame-last-update
-              (= start (cdr git-blame-last-update)))
-         (setcdr git-blame-last-update end))
-        ((and git-blame-last-update
-              (= end (car git-blame-last-update)))
-         (setcar git-blame-last-update start))
+  (cond ((and git-blamed-last-update
+              (= start (cdr git-blamed-last-update)))
+         (setcdr git-blamed-last-update end))
+        ((and git-blamed-last-update
+              (= end (car git-blamed-last-update)))
+         (setcar git-blamed-last-update start))
         (t
-         (setq git-blame-last-update (cons start end))
-         (setq git-blame-update-queue (nconc git-blame-update-queue
-                                             (list git-blame-last-update)))))
-  (unless (or git-blame-proc git-blame-idle-timer)
-    (setq git-blame-idle-timer
-          (run-with-idle-timer 0.5 nil 'git-blame-delayed-update))))
+         (setq git-blamed-last-update (cons start end))
+         (setq git-blamed-update-queue (nconc git-blamed-update-queue
+                                              (list git-blamed-last-update)))))
+  (unless (or git-blamed-proc git-blamed-idle-timer)
+    (setq git-blamed-idle-timer
+          (run-with-idle-timer 0.5 nil 'git-blamed-delayed-update))))
 
-(defun git-blame-delayed-update ()
-  (setq git-blame-idle-timer nil)
-  (if git-blame-update-queue
-      (let ((first (pop git-blame-update-queue))
+(defun git-blamed-delayed-update ()
+  (setq git-blamed-idle-timer nil)
+  (if git-blamed-update-queue
+      (let ((first (pop git-blamed-update-queue))
             (inhibit-point-motion-hooks t))
-        (git-blame-update-region (car first) (cdr first)))))
+        (git-blamed-update-region (car first) (cdr first)))))
 
-(provide 'git-blame)
+(provide 'git-blamed)
 
-;;; git-blame.el ends here
+;;; git-blamed.el ends here


### PR DESCRIPTION
A library git-blame.el is part of Git itself.
Use a different name for this implementation.
